### PR TITLE
Add suport for splunk 7 on freebsd

### DIFF
--- a/splunkforwarder/forwarder/package/download.sls
+++ b/splunkforwarder/forwarder/package/download.sls
@@ -39,6 +39,7 @@ splunkforwarder:
       - file: get-splunkforwarder-package
     - require_in:
       - service: splunkforwarder
+    - force: True
   {%- if grains['os_family'] == 'Debian' %}
   {# Use sysvinit script or systemd based on the following check #}
   {%- if salt['cmd.retcode']('command -v systemctl 2>&1 /dev/null', python_shell=True) == 1 %}


### PR DESCRIPTION
Splunk has provided packages for FreeBSD 11, but are not abi compatible with it. We opened a customer request, and they kindly said that the package can be forced and it will work. So we added forcing install.